### PR TITLE
Port to new agent-object-message API

### DIFF
--- a/opencog/persist/proxy/ProxyNode.cc
+++ b/opencog/persist/proxy/ProxyNode.cc
@@ -158,6 +158,16 @@ StorageNodeSeq ProxyNode::setup(void)
 	return stolist;
 }
 
+void ProxyNode::setValue(const Handle& key, const ValuePtr& value)
+{
+	Atom::setValue(key, value);
+}
+
+ValuePtr ProxyNode::getValue(const Handle& key) const
+{
+	return Atom::getValue(key);
+}
+
 void ProxyNode::destroy(void) {}
 void ProxyNode::erase(void) {}
 

--- a/opencog/persist/proxy/ProxyNode.cc
+++ b/opencog/persist/proxy/ProxyNode.cc
@@ -85,11 +85,13 @@ std::string ProxyNode::monitor(void)
 
 void ProxyNode::setValue(const Handle& key, const ValuePtr& value)
 {
-	// If we don't understand the message, just store it.
+	// Cache, as always.
+	Atom::setValue(key, value);
+
+	// If we don't understand the message, just ignore it.
 	if (PREDICATE_NODE != key->get_type() or
 	    0 != key->get_name().compare("*-proxy-parts-*"))
 	{
-		Atom::setValue(key, value);
 		return;
 	}
 

--- a/opencog/persist/proxy/ProxyNode.cc
+++ b/opencog/persist/proxy/ProxyNode.cc
@@ -83,53 +83,30 @@ std::string ProxyNode::monitor(void)
 	return rpt;
 }
 
-// Get our configuration from the DefineLink we live in.
-// Hmm, perhaps this should be a StateLink?
-//
-// XXX FIXME. Using this ProxyParametersLink thing is a kind of
-// cheesy hack, to pass parameters to the ProxyNode. It vaguely
-// resembles the structure of an ExecutionLink, but instead of
-// writing (Execution (Predicate "foo") (List (args...)))
-// we write (ProxyParameters (Proxy "foo") (List (params...)))
-// Except that we don't have a C++ class for ProxyParameters
-// and it is not executable. So ... I dunno. I'm not happy with
-// this design.
-//
-// More generally there is the work in sensory to create a DTD/IDL
-// to describe parameters. The design work there is not done, but
-// when it is, this should convert to that.
-StorageNodeSeq ProxyNode::setup(void)
+void ProxyNode::setValue(const Handle& key, const ValuePtr& value)
 {
-	StorageNodeSeq stolist;
-
-	IncomingSet dli(getIncomingSetByType(PROXY_PARAMETERS_LINK));
-
-	// We could throw an error here ... or we can just no-op.
-	if (0 == dli.size()) return stolist;
-
-	// Don't know what to do if there are two or more parameter sets.
-	if (1 != dli.size())
+	// If we don't understand the message, just store it.
+	if (PREDICATE_NODE != key->get_type() or
+	    0 != key->get_name().compare("*-proxy-parts-*"))
 	{
-		throw SyntaxException(TRACE_INFO,
-			"Expecting only one set of parameters for a ProxyNode. Got %lu of them:\n%s\n",
-			dli.size(), oc_to_string(dli).c_str());
+		Atom::setValue(key, value);
+		return;
 	}
 
 	// If there is no ListLink, then just grab that.
-	const Handle& params = dli[0]->getOutgoingAtom(1);
-	if (params->is_type(STORAGE_NODE))
+	if (value->is_type(STORAGE_NODE))
 	{
-		stolist.emplace_back(StorageNodeCast(params));
-		return stolist;
+		_parts.emplace_back(StorageNodeCast(HandleCast(value)));
+		return;
 	}
 
-	// Expect the parameters to be wrapped in a ListLink
-	if (not params->is_type(LIST_LINK))
+	// Expect the parts to be wrapped in a ListLink
+	if (not value->is_type(LIST_LINK))
 		throw SyntaxException(TRACE_INFO,
 			"Expecting parameters in a ListLink! Got\n%s\n",
-			dli[0]->to_short_string().c_str());
+			value->to_short_string().c_str());
 
-	for (const Handle& h : params->getOutgoingSet())
+	for (const Handle& h : HandleCast(value)->getOutgoingSet())
 	{
 		StorageNodePtr stnp = StorageNodeCast(h);
 		if (nullptr == stnp)
@@ -145,22 +122,15 @@ StorageNodeSeq ProxyNode::setup(void)
 					"For example: `(use-modules (opencog persist-rocks))`\n"
 					"Config was %s\n",
 					h->to_short_string().c_str(),
-					dli[0]->to_short_string().c_str());
+					value->to_short_string().c_str());
 			}
 			throw SyntaxException(TRACE_INFO,
 				"Expecting a list of Storage or ProxyNodes! Got\n%s\n",
-				dli[0]->to_short_string().c_str());
+				value->to_short_string().c_str());
 		}
 
-		stolist.emplace_back(stnp);
+		_parts.emplace_back(stnp);
 	}
-
-	return stolist;
-}
-
-void ProxyNode::setValue(const Handle& key, const ValuePtr& value)
-{
-	Atom::setValue(key, value);
 }
 
 ValuePtr ProxyNode::getValue(const Handle& key) const

--- a/opencog/persist/proxy/ProxyNode.h
+++ b/opencog/persist/proxy/ProxyNode.h
@@ -36,6 +36,9 @@ class ProxyNode : public StorageNode
 private:
 	void init(void);
 
+protected:
+	StorageNodeSeq _parts;
+
 public:
 	ProxyNode(const std::string&&);
 	ProxyNode(Type t, const std::string&&);
@@ -45,7 +48,7 @@ public:
 	virtual ValuePtr getValue(const Handle& key) const;
 
 	// ----------------------------------------------------------------
-	StorageNodeSeq setup();
+	StorageNodeSeq setup() { return _parts; }
 
 	// Flags. Avoid calling into the proxy, if these are absent.
 	bool have_getAtom;

--- a/opencog/persist/proxy/ProxyNode.h
+++ b/opencog/persist/proxy/ProxyNode.h
@@ -41,6 +41,10 @@ public:
 	ProxyNode(Type t, const std::string&&);
 	virtual ~ProxyNode();
 
+	virtual void setValue(const Handle& key, const ValuePtr& value);
+	virtual ValuePtr getValue(const Handle& key) const;
+
+	// ----------------------------------------------------------------
 	StorageNodeSeq setup();
 
 	// Flags. Avoid calling into the proxy, if these are absent.

--- a/opencog/persist/proxy/WriteBufferProxy.cc
+++ b/opencog/persist/proxy/WriteBufferProxy.cc
@@ -57,11 +57,13 @@ void WriteBufferProxy::init(void)
 
 void WriteBufferProxy::setValue(const Handle& key, const ValuePtr& value)
 {
-	// If we don't understand the message, just pass it on.
+	// Pass it on.
+	ProxyNode::setValue(key, value);
+
+	// If we don't understand the message, just ignore it.
 	if (PREDICATE_NODE != key->get_type() or
 	    0 != key->get_name().compare("*-decay-const-*"))
 	{
-		ProxyNode::setValue(key, value);
 		return;
 	}
 

--- a/opencog/persist/proxy/WriteBufferProxy.h
+++ b/opencog/persist/proxy/WriteBufferProxy.h
@@ -70,6 +70,8 @@ public:
 	WriteBufferProxy(Type, const std::string&&);
 	virtual ~WriteBufferProxy();
 
+	virtual void setValue(const Handle& key, const ValuePtr& value);
+
 	// ----------------------------------------------------------------
 	virtual void open(void);
 	virtual void close(void);

--- a/opencog/persist/sexcom/Commands.cc
+++ b/opencog/persist/sexcom/Commands.cc
@@ -100,7 +100,7 @@ std::string Commands::cog_atomspace_clear(const std::string& arg)
 }
 
 // -----------------------------------------------
-// (cog-set-proxy! (ProxyParameters (ProxyNode "foo") ...))
+// (cog-set-proxy! (ProxyNode "foo"))
 std::string Commands::cog_set_proxy(const std::string& cmd)
 {
 	// If there already is one, do nothing.
@@ -109,29 +109,14 @@ std::string Commands::cog_set_proxy(const std::string& cmd)
 	size_t pos = 0;
 	Handle h = Sexpr::decode_atom(cmd, pos, _space_map);
 
-	// If we got a full definition, the proxy is then just the first atom.
-	if (h->is_type(PROXY_PARAMETERS_LINK))
-	{
-		h = _base_space->add_atom(h);
-		Handle pxy = h->getOutgoingAtom(0);
-		if (pxy and pxy->is_type(PROXY_NODE))
-		{
-			_proxy = ProxyNodeCast(pxy);
-			return "#t";
-		}
+	// If it's not a proxy, its an error.
+	if (not h->is_type(PROXY_NODE))
 		return "#f";
-	}
 
-	// If it's a bare-naked proxy, just set it.
-	if (h->is_type(PROXY_NODE))
-	{
-		h = _base_space->add_atom(h);
-		_proxy = ProxyNodeCast(h);
-		return "#t";
-	}
-
-	// If we are here, its an error.
-	return "#f";
+	// Record the proxy.
+	h = _base_space->add_atom(h);
+	_proxy = ProxyNodeCast(h);
+	return "#t";
 }
 
 // -----------------------------------------------

--- a/opencog/persist/storage/storage_types.script
+++ b/opencog/persist/storage/storage_types.script
@@ -68,11 +68,6 @@ CACHING_PROXY_NODE <- PROXY_NODE
 // Given an (Atom,Key) pair, it computes the appropriate Value on the fly.
 DYNAMIC_DATA_PROXY_NODE <- PROXY_NODE
 
-// Decorate the Proxies with additional parameters.
-// We use the UniqueLink because the DefineLink constructor does
-// checks for DefinedSchema and what-not, which wrecks us.
-PROXY_PARAMETERS_LINK <- UNIQUE_LINK
-
 // ------------------------------------------------------------------
 // Fetch and store Values from Storage.
 // Marked "NUMERIC" only because having a FetchFloatValueOfLink seems

--- a/opencog/persist/storage/storage_types.script
+++ b/opencog/persist/storage/storage_types.script
@@ -3,11 +3,10 @@
 // a collection of types suitable for defining distributed storage
 // interconnects.
 //
-// What's the right base type for all StorageNodes?
-// LexicalNode, cause there's a collection of them.
-// TagNode cause base AtomSpace already calls them "data streams".
-// BondNode cause they are connector-like?
-STORAGE_NODE <- TAG_NODE
+// The ObjectNode is the base class for StorageNode, because all
+// StorageNodes are stateful objects, existing in the real physical
+// world, and accept the messages that define the storage API.
+STORAGE_NODE <- OBJECT_NODE
 //
 // Specific storage nodes. Most of these are implemented in other git
 // repos, and not here. Look for git repos called "atomspace-xxx" for

--- a/tests/persist/proxy/proxy-node-test.scm
+++ b/tests/persist/proxy/proxy-node-test.scm
@@ -20,12 +20,15 @@
 (define tname "proxy-node")
 (test-begin tname)
 
+(define parts (Predicate "*-proxy-parts-*"))
+
 ; This should lead to failure.
 (define foo (WriteThruProxy "foo"))
-(ProxyParametersLink foo (Concept "bar"))
 
 (define caught #f)
-(catch 'C++-EXCEPTION (lambda () (cog-open foo))
+(catch 'C++-EXCEPTION
+	(lambda ()
+		(cog-set-value! foo parts (Concept "bar")))
 	(lambda (key funcname msg)
 		(format #t "Yes, we got the exception as expected\n")
 		(set! caught #t)))
@@ -36,7 +39,7 @@
 ; Assorted permutations -- just one target
 
 (define wnull (WriteThruProxy "wnull"))
-(ProxyParametersLink wnull (NullProxy "bar"))
+(cog-set-value! wnull parts (NullProxy "bar"))
 
 (cog-open wnull)
 (store-atom (Concept "boffo"))
@@ -54,7 +57,7 @@
 ; Multiple targets
 
 (define wmulti (WriteThruProxy "wmulti"))
-(ProxyParametersLink wmulti
+(cog-set-value! wmulti parts
 	(List
 		(NullProxy "foo")
 		(NullProxy "bar")
@@ -77,7 +80,7 @@
 ; Assorted permutations -- just one reader
 
 (define rnull (ReadThruProxy "wnull"))
-(ProxyParametersLink rnull (NullProxy "bar"))
+(cog-set-value! rnull parts (NullProxy "bar"))
 
 (cog-open rnull)
 (fetch-atom (Concept "b1"))
@@ -98,7 +101,7 @@
 ; Multiple readers
 
 (define rmulti (ReadThruProxy "wmulti"))
-(ProxyParametersLink rmulti
+(cog-set-value! rmulti parts
 	(List
 		(NullProxy "foo")
 		(NullProxy "bar")

--- a/tests/persist/proxy/read-proxy-test.scm
+++ b/tests/persist/proxy/read-proxy-test.scm
@@ -18,7 +18,7 @@
 	"postgres:///opencog_test?user=opencog_tester&password=cheese"))
 
 (define wsto (WriteThruProxy "writer"))
-(ProxyParametersLink wsto sto)
+(cog-set-value! wsto (Predicate "*-proxy-parts-*") sto)
 
 (cog-open wsto)
 (store-atom (Concept "b1" (stv 0.1 0.1)))
@@ -36,7 +36,7 @@
 	"postgres:///opencog_test?user=opencog_tester&password=cheese"))
 
 (define rsto (ReadThruProxy "reader"))
-(ProxyParametersLink rsto sto)
+(cog-set-value! rsto (Predicate "*-proxy-parts-*") sto)
 
 (cog-open rsto)
 (fetch-atom (Concept "b1"))


### PR DESCRIPTION
StorageNodes act as agents for the AtomSpace. Give them a generic agent API.

This pull req only handles the ProxyNodes, for now, as these had the worst API. 