### PR TITLE
Continue porting to new messagng API

### DIFF
--- a/opencog/persist/api/PersistSCM.cc
+++ b/opencog/persist/api/PersistSCM.cc
@@ -98,6 +98,11 @@ void PersistSCM::init(void)
 	define_scheme_primitive("sn-monitor",
 	             &PersistSCM::sn_monitor, "persist", false);
 
+	define_scheme_primitive("sn-setvalue",
+	             &PersistSCM::sn_setvalue, "persist", false);
+	define_scheme_primitive("sn-getvalue",
+	             &PersistSCM::sn_getvalue, "persist", false);
+
 	define_scheme_primitive("dflt-fetch-atom",
 	             &PersistSCM::dflt_fetch_atom, this, "persist", false);
 	define_scheme_primitive("dflt-fetch-value",
@@ -144,6 +149,10 @@ void PersistSCM::init(void)
 	             &PersistSCM::dflt_set_proxy, this, "persist", false);
 	define_scheme_primitive("dflt-monitor",
 	             &PersistSCM::dflt_monitor, this, "persist", false);
+	define_scheme_primitive("dflt-setvalue",
+	             &PersistSCM::dflt_setvalue, this, "persist", false);
+	define_scheme_primitive("dflt-getvalue",
+	             &PersistSCM::dflt_getvalue, this, "persist", false);
 }
 
 // =====================================================================
@@ -385,6 +394,18 @@ std::string PersistSCM::sn_monitor(Handle hsn)
 	return stnp->monitor();
 }
 
+void PersistSCM::sn_setvalue(Handle hsn, Handle key, ValuePtr val)
+{
+	GET_STNP;
+	stnp->setValue(key, val);
+}
+
+ValuePtr PersistSCM::sn_getvalue(Handle hsn, Handle key)
+{
+	GET_STNP;
+	return stnp->getValue(key);
+}
+
 // =====================================================================
 
 #define CHECK \
@@ -557,6 +578,18 @@ std::string PersistSCM::dflt_monitor(void)
 	if (nullptr == _sn)
 		return "No open connection to storage!";
 	return _sn->monitor();
+}
+
+void PersistSCM::dflt_setvalue(Handle key, ValuePtr val)
+{
+	CHECK;
+	_sn->setValue(key, val);
+}
+
+ValuePtr PersistSCM::dflt_getvalue(Handle key)
+{
+	CHECK;
+	return _sn->getValue(key);
 }
 
 Handle PersistSCM::current_storage(void)

--- a/opencog/persist/api/PersistSCM.cc
+++ b/opencog/persist/api/PersistSCM.cc
@@ -95,8 +95,6 @@ void PersistSCM::init(void)
 	             &PersistSCM::sn_proxy_close, "persist", false);
 	define_scheme_primitive("sn-set-proxy",
 	             &PersistSCM::sn_set_proxy, "persist", false);
-	define_scheme_primitive("sn-monitor",
-	             &PersistSCM::sn_monitor, "persist", false);
 
 	define_scheme_primitive("sn-setvalue",
 	             &PersistSCM::sn_setvalue, "persist", false);
@@ -147,8 +145,6 @@ void PersistSCM::init(void)
 	             &PersistSCM::dflt_proxy_close, this, "persist", false);
 	define_scheme_primitive("dflt-set-proxy",
 	             &PersistSCM::dflt_set_proxy, this, "persist", false);
-	define_scheme_primitive("dflt-monitor",
-	             &PersistSCM::dflt_monitor, this, "persist", false);
 	define_scheme_primitive("dflt-setvalue",
 	             &PersistSCM::dflt_setvalue, this, "persist", false);
 	define_scheme_primitive("dflt-getvalue",
@@ -388,12 +384,6 @@ void PersistSCM::sn_set_proxy(Handle h, Handle hsn)
 	stnp->set_proxy(h);
 }
 
-std::string PersistSCM::sn_monitor(Handle hsn)
-{
-	GET_STNP;
-	return stnp->monitor();
-}
-
 void PersistSCM::sn_setvalue(Handle hsn, Handle key, ValuePtr val)
 {
 	GET_STNP;
@@ -571,13 +561,6 @@ void PersistSCM::dflt_set_proxy(Handle h)
 {
 	CHECK;
 	_sn->set_proxy(h);
-}
-
-std::string PersistSCM::dflt_monitor(void)
-{
-	if (nullptr == _sn)
-		return "No open connection to storage!";
-	return _sn->monitor();
 }
 
 void PersistSCM::dflt_setvalue(Handle key, ValuePtr val)

--- a/opencog/persist/api/PersistSCM.cc
+++ b/opencog/persist/api/PersistSCM.cc
@@ -89,12 +89,6 @@ void PersistSCM::init(void)
 	             &PersistSCM::sn_erase, "persist", false);
 	define_scheme_primitive("sn-barrier",
 	             &PersistSCM::sn_barrier, "persist", false);
-	define_scheme_primitive("sn-proxy-open",
-	             &PersistSCM::sn_proxy_open, "persist", false);
-	define_scheme_primitive("sn-proxy-close",
-	             &PersistSCM::sn_proxy_close, "persist", false);
-	define_scheme_primitive("sn-set-proxy",
-	             &PersistSCM::sn_set_proxy, "persist", false);
 
 	define_scheme_primitive("sn-setvalue",
 	             &PersistSCM::sn_setvalue, "persist", false);
@@ -139,12 +133,6 @@ void PersistSCM::init(void)
 	             &PersistSCM::dflt_erase, this, "persist", false);
 	define_scheme_primitive("dflt-barrier",
 	             &PersistSCM::dflt_barrier, this, "persist", false);
-	define_scheme_primitive("dflt-proxy-open",
-	             &PersistSCM::dflt_proxy_open, this, "persist", false);
-	define_scheme_primitive("dflt-proxy-close",
-	             &PersistSCM::dflt_proxy_close, this, "persist", false);
-	define_scheme_primitive("dflt-set-proxy",
-	             &PersistSCM::dflt_set_proxy, this, "persist", false);
 	define_scheme_primitive("dflt-setvalue",
 	             &PersistSCM::dflt_setvalue, this, "persist", false);
 	define_scheme_primitive("dflt-getvalue",
@@ -366,24 +354,6 @@ void PersistSCM::sn_erase(Handle hsn)
 	stnp->erase();
 }
 
-void PersistSCM::sn_proxy_open(Handle hsn)
-{
-	GET_STNP;
-	stnp->proxy_open();
-}
-
-void PersistSCM::sn_proxy_close(Handle hsn)
-{
-	GET_STNP;
-	stnp->proxy_close();
-}
-
-void PersistSCM::sn_set_proxy(Handle h, Handle hsn)
-{
-	GET_STNP;
-	stnp->set_proxy(h);
-}
-
 void PersistSCM::sn_setvalue(Handle hsn, Handle key, ValuePtr val)
 {
 	GET_STNP;
@@ -543,24 +513,6 @@ void PersistSCM::dflt_erase(void)
 {
 	CHECK;
 	_sn->erase();
-}
-
-void PersistSCM::dflt_proxy_open(void)
-{
-	CHECK;
-	_sn->proxy_open();
-}
-
-void PersistSCM::dflt_proxy_close(void)
-{
-	CHECK;
-	_sn->proxy_close();
-}
-
-void PersistSCM::dflt_set_proxy(Handle h)
-{
-	CHECK;
-	_sn->set_proxy(h);
 }
 
 void PersistSCM::dflt_setvalue(Handle key, ValuePtr val)

--- a/opencog/persist/api/PersistSCM.h
+++ b/opencog/persist/api/PersistSCM.h
@@ -64,6 +64,8 @@ private:
 	static void sn_proxy_close(Handle);
 	static void sn_set_proxy(Handle, Handle);
 	static std::string sn_monitor(Handle);
+	static void sn_setvalue(Handle, Handle, ValuePtr);
+	static ValuePtr sn_getvalue(Handle, Handle);
 
 	void open(Handle);
 	void close(Handle);
@@ -96,6 +98,8 @@ private:
 	void dflt_set_proxy(Handle);
 	void dflt_barrier(void);
 	std::string dflt_monitor(void);
+	void dflt_setvalue(Handle, ValuePtr);
+	ValuePtr dflt_getvalue(Handle);
 	Handle current_storage(void);
 
 public:

--- a/opencog/persist/api/PersistSCM.h
+++ b/opencog/persist/api/PersistSCM.h
@@ -60,9 +60,6 @@ private:
 	static bool sn_delete_recursive(Handle, Handle);
 	static void sn_erase(Handle);
 	static void sn_barrier(Handle);
-	static void sn_proxy_open(Handle);
-	static void sn_proxy_close(Handle);
-	static void sn_set_proxy(Handle, Handle);
 	static void sn_setvalue(Handle, Handle, ValuePtr);
 	static ValuePtr sn_getvalue(Handle, Handle);
 
@@ -92,9 +89,6 @@ private:
 	bool dflt_delete(Handle);
 	bool dflt_delete_recursive(Handle);
 	void dflt_erase(void);
-	void dflt_proxy_open(void);
-	void dflt_proxy_close(void);
-	void dflt_set_proxy(Handle);
 	void dflt_barrier(void);
 	void dflt_setvalue(Handle, ValuePtr);
 	ValuePtr dflt_getvalue(Handle);

--- a/opencog/persist/api/PersistSCM.h
+++ b/opencog/persist/api/PersistSCM.h
@@ -63,7 +63,6 @@ private:
 	static void sn_proxy_open(Handle);
 	static void sn_proxy_close(Handle);
 	static void sn_set_proxy(Handle, Handle);
-	static std::string sn_monitor(Handle);
 	static void sn_setvalue(Handle, Handle, ValuePtr);
 	static ValuePtr sn_getvalue(Handle, Handle);
 
@@ -97,7 +96,6 @@ private:
 	void dflt_proxy_close(void);
 	void dflt_set_proxy(Handle);
 	void dflt_barrier(void);
-	std::string dflt_monitor(void);
 	void dflt_setvalue(Handle, ValuePtr);
 	ValuePtr dflt_getvalue(Handle);
 	Handle current_storage(void);

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -23,6 +23,7 @@
 
 #include <string>
 
+#include <opencog/atoms/value/StringValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/persist/storage/storage_types.h>
 #include "StorageNode.h"
@@ -49,6 +50,21 @@ void StorageNode::setValue(const Handle& key, const ValuePtr& value)
 
 ValuePtr StorageNode::getValue(const Handle& key) const
 {
+	if (PREDICATE_NODE != key->get_type())
+		return Atom::getValue(key);
+
+	const std::string& pred(key->get_name());
+
+	// XXX FIXME. We get called with *-TruthValueKey-* A LOT
+	// and really it should be zero. WTF. Bug? Needs to get fixed.
+	if (0 == pred.compare("*-TruthValueKey-*"))
+		return Atom::getValue(key);
+
+	if (0 == pred.compare("*-monitor-*"))
+	{
+		return createStringValue(const_cast<StorageNode*>(this)->monitor());
+	}
+
 	return Atom::getValue(key);
 }
 

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -42,6 +42,16 @@ StorageNode::~StorageNode()
 {
 }
 
+void StorageNode::setValue(const Handle& key, const ValuePtr& value)
+{
+	Atom::setValue(key, value);
+}
+
+ValuePtr StorageNode::getValue(const Handle& key) const
+{
+	return Atom::getValue(key);
+}
+
 void StorageNode::proxy_open(void)
 {
 	throw RuntimeException(TRACE_INFO,

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -46,6 +46,29 @@ StorageNode::~StorageNode()
 void StorageNode::setValue(const Handle& key, const ValuePtr& value)
 {
 	Atom::setValue(key, value);
+	if (PREDICATE_NODE != key->get_type())
+		return;
+
+	const std::string& pred(key->get_name());
+
+	if (0 == pred.compare("*-proxy-open-*"))
+	{
+		proxy_open();
+		return;
+	}
+
+	if (0 == pred.compare("*-proxy-close-*"))
+	{
+		proxy_close();
+		return;
+	}
+
+	if (0 == pred.compare("*-set-proxy-*"))
+	{
+		set_proxy(HandleCast(value));
+		return;
+	}
+
 }
 
 ValuePtr StorageNode::getValue(const Handle& key) const
@@ -56,9 +79,7 @@ ValuePtr StorageNode::getValue(const Handle& key) const
 	const std::string& pred(key->get_name());
 
 	if (0 == pred.compare("*-monitor-*"))
-	{
 		return createStringValue(const_cast<StorageNode*>(this)->monitor());
-	}
 
 	return Atom::getValue(key);
 }

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -55,11 +55,6 @@ ValuePtr StorageNode::getValue(const Handle& key) const
 
 	const std::string& pred(key->get_name());
 
-	// XXX FIXME. We get called with *-TruthValueKey-* A LOT
-	// and really it should be zero. WTF. Bug? Needs to get fixed.
-	if (0 == pred.compare("*-TruthValueKey-*"))
-		return Atom::getValue(key);
-
 	if (0 == pred.compare("*-monitor-*"))
 	{
 		return createStringValue(const_cast<StorageNode*>(this)->monitor());

--- a/opencog/persist/api/StorageNode.h
+++ b/opencog/persist/api/StorageNode.h
@@ -53,6 +53,8 @@ public:
 	StorageNode(Type, std::string);
 	virtual ~StorageNode();
 
+	virtual void setValue(const Handle& key, const ValuePtr& value);
+	virtual ValuePtr getValue(const Handle& key) const;
 
 	// ----------------------------------------------------------------
 	// Operations regarding the connection to the remote URI.

--- a/opencog/persist/api/opencog/persist.scm
+++ b/opencog/persist/api/opencog/persist.scm
@@ -722,7 +722,7 @@
 
        (define csn (CogStorageNode \"cog://example.com:17001\"))
        (cog-open csn)
-       (cog-set-value! pxy (Predicate \"*-set-proxy-*\") (VoidValue))
+       (cog-set-value! csn (Predicate \"*-set-proxy-*\") pxy)
        (cog-set-value! csn (Predicate \"*-proxy-open-*\") (VoidValue))
        (store-atom (Concept \"foo\"))
 
@@ -792,4 +792,5 @@
 	(if STORAGE (sn-setvalue STORAGE pkey PROXY)
 		(dflt-setvalue pkey PROXY))
 )
+
 ; --------------------------------------------------------------------

--- a/opencog/persist/api/opencog/persist.scm
+++ b/opencog/persist/api/opencog/persist.scm
@@ -397,6 +397,10 @@
 "
  monitor-storage [STORAGE]
 
+    Deprecated! Instead, send the (Predicate \"*-monitor-*\") message
+    to the StorageNode directly. This can be done with
+    (cog-value (StorageNode ...) (Predicate \"*-monitor-*\"))
+
     Return a string containing storage performance monitoring and
     debugging information. To display the string in a properly
     formatted fashion, say `(display (monitor-storage))`.
@@ -413,7 +417,8 @@
        `cog-connected?` to obtain the connection status.
        `cog-storage-node` to obtain the current connection.
 "
-	(if STORAGE (sn-monitor STORAGE) (dflt-monitor))
+	(define mkey (PredicateNode "*-monitor-*"))
+	(if STORAGE (sn-getvalue STORAGE mkey) (dflt-getvalue mkey))
 )
 
 (define*-public (load-atomspace #:optional (ATOMSPACE #f) (STORAGE #f))

--- a/opencog/persist/api/opencog/persist.scm
+++ b/opencog/persist/api/opencog/persist.scm
@@ -41,12 +41,12 @@
 	cog-delete-recursive!
 	barrier
 	cog-erase!
-	monitor-storage
 	load-atomspace
 	store-atomspace
 	load-frames
 	store-frames
-	delete-frame!)
+	delete-frame!
+	monitor-storage)
 
 ;; -----------------------------------------------------
 ;;
@@ -66,7 +66,6 @@
        `cog-close` to close a connection.
        `cog-connected?` to obtain the connection status.
        `cog-storage-node` to obtain the current connection.
-       `monitor-storage` to print connection information.
 ")
 
 (set-procedure-property! cog-close 'documentation
@@ -86,7 +85,6 @@
        `cog-open` to open a connection.
        `cog-connected?` to obtain the connection status.
        `cog-storage-node` to obtain the current connection.
-       `monitor-storage` to print connection information.
 ")
 
 (set-procedure-property! cog-connected? 'documentation
@@ -100,7 +98,6 @@
        `cog-open` to open a connection.
        `cog-close` to close a connection.
        `cog-storage-node` to obtain the current connection.
-       `monitor-storage` to print connection information.
 ")
 
 (set-procedure-property! cog-storage-node 'documentation
@@ -117,7 +114,6 @@
        `cog-open` to open a connection.
        `cog-close` to close a connection.
        `cog-connected?` to obtain the connection status.
-       `monitor-storage` to print connection information.
 ")
 
 (define*-public (fetch-atom ATOM #:optional (STORAGE #f))
@@ -391,34 +387,6 @@
        `cog-proxy-close` to stop proxying.
 "
 	(if STORAGE (sn-set-proxy PROXY STORAGE) (dflt-set-proxy PROXY))
-)
-
-(define*-public (monitor-storage #:optional (STORAGE #f))
-"
- monitor-storage [STORAGE]
-
-    Deprecated! Instead, send the (Predicate \"*-monitor-*\") message
-    to the StorageNode directly. This can be done with
-    (cog-value (StorageNode ...) (Predicate \"*-monitor-*\"))
-
-    Return a string containing storage performance monitoring and
-    debugging information. To display the string in a properly
-    formatted fashion, say `(display (monitor-storage))`.
-
-    If the optional STORAGE argument is provided, then the statistics
-    will be printed for that Node. It must be a StorageNode.
-
-    Note that some StorageNodes might do significant computations
-    before returning a report, and thus may appear to hang. Patience!
-
-    See also:
-       `cog-open` to open a connection.
-       `cog-close` to close a connection.
-       `cog-connected?` to obtain the connection status.
-       `cog-storage-node` to obtain the current connection.
-"
-	(define mkey (PredicateNode "*-monitor-*"))
-	(if STORAGE (sn-getvalue STORAGE mkey) (dflt-getvalue mkey))
 )
 
 (define*-public (load-atomspace #:optional (ATOMSPACE #f) (STORAGE #f))
@@ -763,6 +731,39 @@
 			(if (and sn (cog-connected? sn))
 				(dflt-delete-rec ATOM)
 				(cog-extract-recursive! ATOM))))
+)
+
+; --------------------------------------------------------------------
+; --------------------------------------------------------------------
+; --------------------------------------------------------------------
+; Deprecated calls. Remove soon.
+
+(define*-public (monitor-storage #:optional (STORAGE #f))
+"
+ monitor-storage [STORAGE]
+
+    Deprecated! Instead, send the (Predicate \"*-monitor-*\") message
+    to the StorageNode directly. This can be done with
+    (cog-value (StorageNode ...) (Predicate \"*-monitor-*\"))
+
+    Return a string containing storage performance monitoring and
+    debugging information. To display the string in a properly
+    formatted fashion, say `(display (monitor-storage))`.
+
+    If the optional STORAGE argument is provided, then the statistics
+    will be printed for that Node. It must be a StorageNode.
+
+    Note that some StorageNodes might do significant computations
+    before returning a report, and thus may appear to hang. Patience!
+
+    See also:
+       `cog-open` to open a connection.
+       `cog-close` to close a connection.
+       `cog-connected?` to obtain the connection status.
+       `cog-storage-node` to obtain the current connection.
+"
+	(define mkey (PredicateNode "*-monitor-*"))
+	(if STORAGE (sn-getvalue STORAGE mkey) (dflt-getvalue mkey))
 )
 
 ; --------------------------------------------------------------------

--- a/opencog/persist/proxy/ProxyNode.cc
+++ b/opencog/persist/proxy/ProxyNode.cc
@@ -86,7 +86,7 @@ std::string ProxyNode::monitor(void)
 void ProxyNode::setValue(const Handle& key, const ValuePtr& value)
 {
 	// Cache, as always.
-	Atom::setValue(key, value);
+	StorageNode::setValue(key, value);
 
 	// If we don't understand the message, just ignore it.
 	if (PREDICATE_NODE != key->get_type() or
@@ -137,7 +137,7 @@ void ProxyNode::setValue(const Handle& key, const ValuePtr& value)
 
 ValuePtr ProxyNode::getValue(const Handle& key) const
 {
-	return Atom::getValue(key);
+	return StorageNode::getValue(key);
 }
 
 void ProxyNode::destroy(void) {}


### PR DESCRIPTION
Replace four more API calls with messages. This time:
`monitor-storage` , `cog-set-proxy!`,  `cog-proxy-open` and  `cog-proxy-close`. The matching messages are
```
 (Predicate "*-monitor-*")
 (Predicate "*-proxy-open-*")
 (Predicate "*-proxy-close-*")
 (Predicate "*-set-proxy-*")
```